### PR TITLE
Update model api to use plumber 1.0 form

### DIFF
--- a/R/model-api/entrypoint.R
+++ b/R/model-api/entrypoint.R
@@ -1,30 +1,35 @@
+# The interface for setting the api specification changed with plumber 1.0
+# and so this no longer reflects what's in the rstudio conference talk. This 
+# is the current way to set the request body in swagger.
+
 library(plumber)
 
 pr <- plumb("plumber.R")
 
-pr$run(port = 5762,
-      swagger = function(pr, spec, ...){
-        # Define request body for POST to /predict
-        spec$paths$`/predict`$post$requestBody <- list(
-          description = "New data to predict",
-          required = TRUE,
-          content = list(
-            `application/json` = list(
-              # Define JSON schema
-              schema = list(
-                title = "Car",
-                required = c("cyl", "hp"),
-                properties = list(
-                  cyl = list(
-                    type = "integer"
-                  ),
-                  hp = list(
-                    type = "integer"
-                  )
+pr <- pr %>%
+  pr_set_api_spec(function(spec) {
+      # Define request body for POST to /predict
+      spec$paths$`/predict`$post$requestBody <- list(
+        description = "New data to predict",
+        required = TRUE,
+        content = list(
+          `application/json` = list(
+            # Define JSON schema
+            schema = list(
+              title = "Car",
+              required = c("cyl", "hp"),
+              properties = list(
+                cyl = list(
+                  type = "integer"
+                ),
+                hp = list(
+                  type = "integer"
                 )
               )
             )
           )
         )
-        spec
-      })
+      )
+      spec
+    }) 
+pr


### PR DESCRIPTION
The model-api endpoint was not runnable using the either the CRAN or dev versions of plumber. This is a small rewrite using the functional form which works as far as I can tell. 